### PR TITLE
Add CI build using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI Build
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - .editorconfig
+      - .gitignore
+      - LICENCE
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-2019, ubuntu-20.04, macos-10.15 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Stack (Windows)
+        run: choco install haskell-stack
+        if: matrix.os == 'windows-2019'
+
+      - name: Install Stack (MacOS)
+        run: curl -sSL https://get.haskellstack.org/ | sh
+        if: matrix.os == 'macos-10.15'
+
+      - name: Cache Stack GHC and Dependencies (Unix)
+        uses: actions/cache@v2
+        if: matrix.os != 'windows-2019'
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
+
+      - name: Cache Stack Dependencies (Windows)
+        uses: actions/cache@v2
+        if: matrix.os == 'windows-2019'
+        with:
+          path: '%SystemDrive%\sr'
+          key: ${{ runner.os }}-stack-deps-${{ hashFiles('stack.yaml.lock') }}
+
+      - name: Cache Stack GHC (Windows)
+        uses: actions/cache@v2
+        if: matrix.os == 'windows-2019'
+        with:
+          path: '%USERPROFILE%\AppData\Local\Programs\stack'
+          key: ${{ runner.os }}-stack-deps-${{ hashFiles('stack.yaml.lock') }}
+
+      - name: Build
+        run: stack build
+
+      - name: Copy Binary
+        shell: bash
+        run: |
+          mkdir bin
+          binDir=$(stack path --dist-dir)/build/local-managed-identity-exe
+          [[ -e "$binDir/local-managed-identity-exe.exe" ]] && cp "$binDir/local-managed-identity-exe.exe" ./bin/local-managed-identity.exe
+          [[ -e "$binDir/local-managed-identity-exe" ]] && cp "$binDir/local-managed-identity-exe" ./bin/local-managed-identity
+
+      - name: Upload Package
+        uses: actions/upload-artifact@v1
+        with:
+          name: local-managed-identity-${{ runner.os }}
+          path: bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - ubuntu-20.04
+          # - ubuntu-20.04
           # Remove MacOS for now while Thyme fails to build: https://github.com/liyang/thyme/issues/72
           # - macos-10.15
 
@@ -39,18 +39,24 @@ jobs:
           key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}
 
       - name: Build
-        run: stack build
-
-      - name: Copy Binary
         shell: bash
         run: |
-          mkdir bin
-          binDir=$(stack path --dist-dir)/build/local-managed-identity-exe
-          [[ -e "$binDir/local-managed-identity-exe.exe" ]] && cp "$binDir/local-managed-identity-exe.exe" ./bin/local-managed-identity.exe
-          [[ -e "$binDir/local-managed-identity-exe" ]] && cp "$binDir/local-managed-identity-exe" ./bin/local-managed-identity
+          stack path
+          echo "STACK_ROOT=$STACK_ROOT"
 
-      - name: Upload Package
-        uses: actions/upload-artifact@v1
-        with:
-          name: local-managed-identity-${{ runner.os }}
-          path: bin
+      # - name: Build
+      #   run: stack build
+
+      # - name: Copy Binary
+      #   shell: bash
+      #   run: |
+      #     mkdir bin
+      #     binDir=$(stack path --dist-dir)/build/local-managed-identity-exe
+      #     [[ -e "$binDir/local-managed-identity-exe.exe" ]] && cp "$binDir/local-managed-identity-exe.exe" ./bin/local-managed-identity.exe
+      #     [[ -e "$binDir/local-managed-identity-exe" ]] && cp "$binDir/local-managed-identity-exe" ./bin/local-managed-identity
+
+      # - name: Upload Package
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: local-managed-identity-${{ runner.os }}
+      #     path: bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
         uses: actions/cache@v2
         if: matrix.os == 'windows-2019'
         with:
-          path: '~/AppData/Local/Programs/stack'
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}-v2
+          path: |
+            ~/AppData/Local/Programs/stack
+            ~/AppData/Roaming/stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}-v3
 
       - name: Build
         run: stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macos-10.15 ]
+        os:
+          - windows-2019
+          - ubuntu-20.04
+          # Remove MacOS for now while Thyme fails to build: https://github.com/liyang/thyme/issues/72
+          # - macos-10.15
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,28 +35,22 @@ jobs:
         uses: actions/cache@v2
         if: matrix.os == 'windows-2019'
         with:
-          path: '%LOCALAPPDATA%\Programs\stack'
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}
+          path: '~/AppData/Local/Programs/stack'
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}-v2
 
       - name: Build
+        run: stack build
+
+      - name: Copy Binary
         shell: bash
         run: |
-          stack path
-          echo "STACK_ROOT=$STACK_ROOT"
+          mkdir bin
+          binDir=$(stack path --dist-dir)/build/local-managed-identity-exe
+          [[ -e "$binDir/local-managed-identity-exe.exe" ]] && cp "$binDir/local-managed-identity-exe.exe" ./bin/local-managed-identity.exe
+          [[ -e "$binDir/local-managed-identity-exe" ]] && cp "$binDir/local-managed-identity-exe" ./bin/local-managed-identity
 
-      # - name: Build
-      #   run: stack build
-
-      # - name: Copy Binary
-      #   shell: bash
-      #   run: |
-      #     mkdir bin
-      #     binDir=$(stack path --dist-dir)/build/local-managed-identity-exe
-      #     [[ -e "$binDir/local-managed-identity-exe.exe" ]] && cp "$binDir/local-managed-identity-exe.exe" ./bin/local-managed-identity.exe
-      #     [[ -e "$binDir/local-managed-identity-exe" ]] && cp "$binDir/local-managed-identity-exe" ./bin/local-managed-identity
-
-      # - name: Upload Package
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: local-managed-identity-${{ runner.os }}
-      #     path: bin
+      - name: Upload Package
+        uses: actions/upload-artifact@v1
+        with:
+          name: local-managed-identity-${{ runner.os }}
+          path: bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,14 @@ jobs:
         if: matrix.os != 'windows-2019'
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}
 
       - name: Cache Stack GHC and Dependencies (Windows)
         uses: actions/cache@v2
         if: matrix.os == 'windows-2019'
         with:
           path: '%LOCALAPPDATA%\Programs\stack'
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}
 
       - name: Build
         run: stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Stack (Windows)
-        run: choco install haskell-stack
-        if: matrix.os == 'windows-2019'
-
-      - name: Install Stack (MacOS)
-        run: curl -sSL https://get.haskellstack.org/ | sh
-        if: matrix.os == 'macos-10.15'
-
       - name: Cache Stack GHC and Dependencies (Unix)
         uses: actions/cache@v2
         if: matrix.os != 'windows-2019'
@@ -34,19 +26,12 @@ jobs:
           path: ~/.stack
           key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
 
-      - name: Cache Stack Dependencies (Windows)
+      - name: Cache Stack GHC and Dependencies (Windows)
         uses: actions/cache@v2
         if: matrix.os == 'windows-2019'
         with:
-          path: '%SystemDrive%\sr'
-          key: ${{ runner.os }}-stack-deps-${{ hashFiles('stack.yaml.lock') }}
-
-      - name: Cache Stack GHC (Windows)
-        uses: actions/cache@v2
-        if: matrix.os == 'windows-2019'
-        with:
-          path: '%USERPROFILE%\AppData\Local\Programs\stack'
-          key: ${{ runner.os }}-stack-deps-${{ hashFiles('stack.yaml.lock') }}
+          path: '%LOCALAPPDATA%\Programs\stack'
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
 
       - name: Build
         run: stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         if: matrix.os != 'windows-2019'
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
 
       - name: Cache Stack GHC and Dependencies (Windows)
         uses: actions/cache@v2
@@ -38,7 +38,7 @@ jobs:
           path: |
             ~/AppData/Local/Programs/stack
             ~/AppData/Roaming/stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'local-managed-identity.cabal') }}-v3
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}-v3
 
       - name: Build
         run: stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          # - ubuntu-20.04
+          - ubuntu-20.04
           # Remove MacOS for now while Thyme fails to build: https://github.com/liyang/thyme/issues/72
           # - macos-10.15
 


### PR DESCRIPTION
Added a CI build that builds for both Windows and Linux (Ubuntu) and captures the executables as artifacts. Mac is disabled for now since Thyme does not build (appears to be due to this issue: https://github.com/liyang/thyme/issues/72)